### PR TITLE
Permitir generar correos ilimitados y mostrar aviso de copiado

### DIFF
--- a/email_creator.html
+++ b/email_creator.html
@@ -132,6 +132,28 @@
         display: block;
       }
 
+      .aviso-copiado {
+        position: fixed;
+        right: 1.5rem;
+        bottom: 1.5rem;
+        background: #1f2933;
+        color: #ffffff;
+        font-weight: 600;
+        padding: 0.6rem 1.2rem;
+        border-radius: 999px;
+        box-shadow: 0 18px 38px rgba(15, 23, 42, 0.18);
+        opacity: 0;
+        transform: translateY(12px);
+        pointer-events: none;
+        transition: opacity 0.25s ease, transform 0.25s ease;
+        z-index: 1000;
+      }
+
+      .aviso-copiado.visible {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
       .resultados {
         margin-top: 2.5rem;
         background: #f8fafc;
@@ -201,6 +223,12 @@
           padding-left: 0.85rem;
         }
       }
+
+      @media (prefers-reduced-motion: reduce) {
+        .aviso-copiado {
+          transition: none;
+        }
+      }
     </style>
   </head>
   <body>
@@ -255,7 +283,6 @@
             name="quantity"
             type="number"
             min="1"
-            max="100"
             step="1"
             inputmode="numeric"
             value="1"
@@ -265,8 +292,8 @@
         <div class="acciones">
           <button type="submit">Generar correos</button>
           <p class="ayuda">
-            Puedes generar hasta 100 correos por vez. Todos los caracteres se
-            crearán de forma aleatoria.
+            Puedes generar tantos correos como necesites. Todos los caracteres
+            se crearán de forma aleatoria.
           </p>
         </div>
         <p class="mensaje-error" id="error" role="alert"></p>
@@ -287,6 +314,13 @@
         </div>
       </section>
     </div>
+    <div
+      class="aviso-copiado"
+      id="aviso-copiado"
+      role="status"
+      aria-live="polite"
+      aria-hidden="true"
+    ></div>
     <script>
       const form = document.getElementById("email-form");
       const lettersInput = document.getElementById("letters");
@@ -300,6 +334,9 @@
       const actionsContainer = document.getElementById("acciones-resultados");
       const copyButton = document.getElementById("copiar-correos");
       const downloadButton = document.getElementById("descargar-correos");
+      const copyNotice = document.getElementById("aviso-copiado");
+
+      let copyNoticeTimeoutId;
 
       const letras = "abcdefghijklmnopqrstuvwxyz";
       const numeros = "0123456789";
@@ -312,6 +349,25 @@
       function limpiarError() {
         errorBox.textContent = "";
         errorBox.classList.remove("visible");
+      }
+
+      function mostrarAvisoCopiado(texto = "Correos copiados") {
+        if (!copyNotice) {
+          return;
+        }
+
+        copyNotice.textContent = texto;
+        copyNotice.classList.add("visible");
+        copyNotice.setAttribute("aria-hidden", "false");
+
+        if (copyNoticeTimeoutId) {
+          window.clearTimeout(copyNoticeTimeoutId);
+        }
+
+        copyNoticeTimeoutId = window.setTimeout(() => {
+          copyNotice.classList.remove("visible");
+          copyNotice.setAttribute("aria-hidden", "true");
+        }, 2200);
       }
 
       function mezclar(arreglo) {
@@ -373,6 +429,7 @@
             }
           }
           limpiarError();
+          mostrarAvisoCopiado();
         } catch (error) {
           mostrarError(
             "No fue posible copiar los correos automáticamente. Puedes descargarlos en un archivo."
@@ -460,13 +517,9 @@
           return;
         }
 
-        if (
-          Number.isNaN(cantidadSolicitada) ||
-          cantidadSolicitada < 1 ||
-          cantidadSolicitada > Number.parseInt(quantityInput.max, 10)
-        ) {
+        if (Number.isNaN(cantidadSolicitada) || cantidadSolicitada < 1) {
           mostrarError(
-            `La cantidad de correos debe estar entre 1 y ${quantityInput.max}.`
+            "La cantidad de correos debe ser un número mayor o igual a 1."
           );
           quantityInput.focus();
           return;


### PR DESCRIPTION
## Summary
- quitar el límite de 100 direcciones configurables y adaptar la validación y el texto de ayuda
- añadir un aviso flotante accesible que confirma cuando los correos se copian correctamente

## Testing
- no se ejecutaron pruebas automatizadas (contenido HTML/JS estático)


------
https://chatgpt.com/codex/tasks/task_b_68ca1021a9b0832a82c53ea33bbf0c2c